### PR TITLE
Use softer assignment for PREFERRED_PROVIDER_virtual/kernel

### DIFF
--- a/conf/distro/mvista-cgx.conf
+++ b/conf/distro/mvista-cgx.conf
@@ -116,8 +116,8 @@ INHERIT += "cgx-profiles"
 BUILDCFG_VARS_append = " CGX_PROFILES "
 
 # export complete path of compiler
-OECMAKE_C_COMPILER_class-target = "$(which $(echo ${CC} | sed 's/^\([^ ]*\)./\1/'))"
-OECMAKE_CXX_COMPILER_class-target = "$(which $(echo ${CXX} | sed 's/^\([^ ]*\)./\1/'))"
+OECMAKE_C_COMPILER_class-target = "$(which $(echo ${CC} | sed 's/^\([^ ]*\).*/\1/'))"
+OECMAKE_CXX_COMPILER_class-target = "$(which $(echo ${CXX} | sed 's/^\([^ ]*\).*/\1/'))"
 
 # Include feature selection file, which includes kernel fragments
 # files (.cfg) and dependent userspace applications based on available


### PR DESCRIPTION
This allows BSP layer or config file to override
PREFERRED_PROVIDER_virtual/kernel based on their needs.

Signed-off-by: Jagadeesh Krishnanjanappa <jkrishnanjanappa@mvista.com>